### PR TITLE
Fix info hash hex conversion for ABI-1

### DIFF
--- a/cpp_xl_dl_demo/torrent_helper.cpp
+++ b/cpp_xl_dl_demo/torrent_helper.cpp
@@ -257,7 +257,15 @@ std::string TorrentDownloader::GetInfoHashHex() const {
     
     try {
         sha1_hash info_hash = pImpl->handle.info_hash();
-        return aux::to_hex(span<char const>(info_hash.data(), info_hash.size()));
+        std::string info_hash_bytes = info_hash.to_string();
+        static constexpr char hex_digits[] = "0123456789abcdef";
+        std::string info_hash_hex;
+        info_hash_hex.reserve(info_hash_bytes.size() * 2);
+        for (unsigned char byte : info_hash_bytes) {
+            info_hash_hex.push_back(hex_digits[byte >> 4]);
+            info_hash_hex.push_back(hex_digits[byte & 0x0f]);
+        }
+        return info_hash_hex;
     }
     catch (const std::exception&) {
         return "";


### PR DESCRIPTION
## Summary
- replace the ABI-2-only aux::to_hex(span) call with a local hex encoding of the info hash bytes to support ABI-1 builds

## Testing
- cmake -S cpp_xl_dl_demo -B build *(fails: missing libtorrent development package in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6bad30548332b75d318e0edbac53